### PR TITLE
Heapless update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ license = "Apache-2.0"
 [dependencies]
 nb = "1"
 no-std-net = "0.4"
-heapless = "^0.5"
+heapless = "^0.7"

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -1,109 +1,86 @@
-pub use no_std_net::{
-    IpAddr,
-    Ipv4Addr,
-    Ipv6Addr,
-    SocketAddr,
-    SocketAddrV4,
-    SocketAddrV6,
-};
+pub use no_std_net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
-use heapless::{
-    String,
-    consts::U256,
-};
 use core::str::FromStr;
+use heapless::{consts::U256, String};
 
 #[derive(Debug)]
 pub struct HostAddr {
-    ip: IpAddr,
-    hostname: Option<String<U256>>,
+	ip: IpAddr,
+	hostname: Option<String<U256>>,
 }
 
 impl HostAddr {
-    pub fn new(ip: IpAddr, hostname: Option<String<U256>>) -> Self {
-        HostAddr {
-            ip,
-            hostname,
-        }
-    }
+	pub fn new(ip: IpAddr, hostname: Option<String<U256>>) -> Self {
+		HostAddr { ip, hostname }
+	}
 
-    pub fn ipv4(octets: [u8;4]) -> HostAddr {
-        HostAddr {
-            ip: IpAddr::from(octets),
-            hostname: None
-        }
-    }
+	pub fn ipv4(octets: [u8; 4]) -> HostAddr {
+		HostAddr {
+			ip: IpAddr::from(octets),
+			hostname: None,
+		}
+	}
 
-    pub fn ipv6(octets: [u8;16]) -> HostAddr {
-        HostAddr {
-            ip: IpAddr::from(octets),
-            hostname: None
-        }
-    }
+	pub fn ipv6(octets: [u8; 16]) -> HostAddr {
+		HostAddr {
+			ip: IpAddr::from(octets),
+			hostname: None,
+		}
+	}
 
-    pub fn ip(&self) -> IpAddr {
-        self.ip
-    }
+	pub fn ip(&self) -> IpAddr {
+		self.ip
+	}
 
-    pub fn hostname(&self) -> Option<&String<U256>> {
-        self.hostname.as_ref()
-    }
+	pub fn hostname(&self) -> Option<&String<U256>> {
+		self.hostname.as_ref()
+	}
 }
 
 #[derive(Debug)]
 pub struct AddrParseError;
 
 impl FromStr for HostAddr {
-    type Err = AddrParseError;
+	type Err = AddrParseError;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(HostAddr::new(
-            IpAddr::from_str(s).map_err(|_| AddrParseError)?,
-            Some(String::from_str(s).unwrap()),
-        ))
-    }
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		Ok(HostAddr::new(
+			IpAddr::from_str(s).map_err(|_| AddrParseError)?,
+			Some(String::from_str(s).unwrap()),
+		))
+	}
 }
 
 impl From<IpAddr> for HostAddr {
-    fn from(ip: IpAddr) -> Self {
-        HostAddr {
-            ip,
-            hostname: None,
-        }
-    }
+	fn from(ip: IpAddr) -> Self {
+		HostAddr { ip, hostname: None }
+	}
 }
 
 #[derive(Debug)]
 pub struct HostSocketAddr {
-    addr: HostAddr,
-    port: u16,
+	addr: HostAddr,
+	port: u16,
 }
 
 impl HostSocketAddr {
-    pub fn new(addr: HostAddr, port: u16) -> HostSocketAddr {
-        HostSocketAddr {
-            addr,
-            port,
-        }
-    }
+	pub fn new(addr: HostAddr, port: u16) -> HostSocketAddr {
+		HostSocketAddr { addr, port }
+	}
 
-    pub fn from(addr: &str, port: u16) -> Result<HostSocketAddr, AddrParseError> {
-        Ok( Self::new(
-            HostAddr::from_str(addr)?,
-            port
-        ) )
-    }
+	pub fn from(addr: &str, port: u16) -> Result<HostSocketAddr, AddrParseError> {
+		Ok(Self::new(HostAddr::from_str(addr)?, port))
+	}
 
-    pub fn addr(&self) -> &HostAddr {
-        &self.addr
-    }
+	pub fn addr(&self) -> &HostAddr {
+		&self.addr
+	}
 
-    pub fn port(&self) -> u16 {
-        self.port
-    }
+	pub fn port(&self) -> u16 {
+		self.port
+	}
 
-    pub fn as_socket_addr(&self) -> SocketAddr {
-        SocketAddr::new(self.addr.ip, self.port)
-    }
+	pub fn as_socket_addr(&self) -> SocketAddr {
+		SocketAddr::new(self.addr.ip, self.port)
+	}
 }
-

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -1,109 +1,86 @@
-pub use no_std_net::{
-    IpAddr,
-    Ipv4Addr,
-    Ipv6Addr,
-    SocketAddr,
-    SocketAddrV4,
-    SocketAddrV6,
-};
+pub use no_std_net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
-use heapless::{
-    String,
-    consts::U256,
-};
 use core::str::FromStr;
+use heapless::String;
 
 #[derive(Debug)]
 pub struct HostAddr {
-    ip: IpAddr,
-    hostname: Option<String<U256>>,
+	ip: IpAddr,
+	hostname: Option<String<256>>,
 }
 
 impl HostAddr {
-    pub fn new(ip: IpAddr, hostname: Option<String<U256>>) -> Self {
-        HostAddr {
-            ip,
-            hostname,
-        }
-    }
+	pub fn new(ip: IpAddr, hostname: Option<String<256>>) -> Self {
+		HostAddr { ip, hostname }
+	}
 
-    pub fn ipv4(octets: [u8;4]) -> HostAddr {
-        HostAddr {
-            ip: IpAddr::from(octets),
-            hostname: None
-        }
-    }
+	pub fn ipv4(octets: [u8; 4]) -> HostAddr {
+		HostAddr {
+			ip: IpAddr::from(octets),
+			hostname: None,
+		}
+	}
 
-    pub fn ipv6(octets: [u8;16]) -> HostAddr {
-        HostAddr {
-            ip: IpAddr::from(octets),
-            hostname: None
-        }
-    }
+	pub fn ipv6(octets: [u8; 16]) -> HostAddr {
+		HostAddr {
+			ip: IpAddr::from(octets),
+			hostname: None,
+		}
+	}
 
-    pub fn ip(&self) -> IpAddr {
-        self.ip
-    }
+	pub fn ip(&self) -> IpAddr {
+		self.ip
+	}
 
-    pub fn hostname(&self) -> Option<&String<U256>> {
-        self.hostname.as_ref()
-    }
+	pub fn hostname(&self) -> Option<&String<256>> {
+		self.hostname.as_ref()
+	}
 }
 
 #[derive(Debug)]
 pub struct AddrParseError;
 
 impl FromStr for HostAddr {
-    type Err = AddrParseError;
+	type Err = AddrParseError;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(HostAddr::new(
-            IpAddr::from_str(s).map_err(|_| AddrParseError)?,
-            Some(String::from_str(s).unwrap()),
-        ))
-    }
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		Ok(HostAddr::new(
+			IpAddr::from_str(s).map_err(|_| AddrParseError)?,
+			Some(String::from_str(s).unwrap()),
+		))
+	}
 }
 
 impl From<IpAddr> for HostAddr {
-    fn from(ip: IpAddr) -> Self {
-        HostAddr {
-            ip,
-            hostname: None,
-        }
-    }
+	fn from(ip: IpAddr) -> Self {
+		HostAddr { ip, hostname: None }
+	}
 }
 
 #[derive(Debug)]
 pub struct HostSocketAddr {
-    addr: HostAddr,
-    port: u16,
+	addr: HostAddr,
+	port: u16,
 }
 
 impl HostSocketAddr {
-    pub fn new(addr: HostAddr, port: u16) -> HostSocketAddr {
-        HostSocketAddr {
-            addr,
-            port,
-        }
-    }
+	pub fn new(addr: HostAddr, port: u16) -> HostSocketAddr {
+		HostSocketAddr { addr, port }
+	}
 
-    pub fn from(addr: &str, port: u16) -> Result<HostSocketAddr, AddrParseError> {
-        Ok( Self::new(
-            HostAddr::from_str(addr)?,
-            port
-        ) )
-    }
+	pub fn from(addr: &str, port: u16) -> Result<HostSocketAddr, AddrParseError> {
+		Ok(Self::new(HostAddr::from_str(addr)?, port))
+	}
 
-    pub fn addr(&self) -> &HostAddr {
-        &self.addr
-    }
+	pub fn addr(&self) -> &HostAddr {
+		&self.addr
+	}
 
-    pub fn port(&self) -> u16 {
-        self.port
-    }
+	pub fn port(&self) -> u16 {
+		self.port
+	}
 
-    pub fn as_socket_addr(&self) -> SocketAddr {
-        SocketAddr::new(self.addr.ip, self.port)
-    }
+	pub fn as_socket_addr(&self) -> SocketAddr {
+		SocketAddr::new(self.addr.ip, self.port)
+	}
 }
-

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -8,8 +8,8 @@ use core::fmt::Debug;
 /// DNS errors
 #[derive(Debug)]
 pub enum DnsError {
-    UnsupportedAddressType,
-    NoSuchHost,
+	UnsupportedAddressType,
+	NoSuchHost,
 }
 
 /// This is the host address type to be returned by `gethostbyname`.
@@ -18,12 +18,12 @@ pub enum DnsError {
 /// will look for `AAAA` records
 #[derive(Clone, Debug, PartialEq)]
 pub enum AddrType {
-    /// Result is `A` record
-    IPv4,
-    /// Result is `AAAA` record
-    IPv6,
-    /// Result is either a `A` record, or a `AAAA` record
-    Either,
+	/// Result is `A` record
+	IPv4,
+	/// Result is `AAAA` record
+	IPv6,
+	/// Result is either a `A` record, or a `AAAA` record
+	Either,
 }
 
 /// This trait is an extension trait for [`TcpStack`] and [`UdpStack`] for dns
@@ -37,18 +37,18 @@ pub enum AddrType {
 /// [`ToSocketAddrs`]:
 /// https://doc.rust-lang.org/std/net/trait.ToSocketAddrs.html
 pub trait Dns {
-    /// The type returned when we have an error
-    type Error: Into<DnsError> + Debug;
+	/// The type returned when we have an error
+	type Error: Into<DnsError> + Debug;
 
-    /// Resolve the first ip address of a host, given its hostname and a desired
-    /// address record type to look for
-    fn gethostbyname(&self, hostname: &str, addr_type: AddrType) -> Result<HostAddr, Self::Error>;
+	/// Resolve the first ip address of a host, given its hostname and a desired
+	/// address record type to look for
+	fn gethostbyname(&self, hostname: &str, addr_type: AddrType) -> Result<HostAddr, Self::Error>;
 
-    /// Resolve the hostname of a host, given its ip address
-    ///
-    /// **Note**: A fully qualified domain name (FQDN), has a maximum length of
-    /// 255 bytes [`rfc1035`]
-    ///
-    /// [`rfc1035`]: https://tools.ietf.org/html/rfc1035
-    fn gethostbyaddr(&self, addr: IpAddr) -> Result<String<consts::U256>, Self::Error>;
+	/// Resolve the hostname of a host, given its ip address
+	///
+	/// **Note**: A fully qualified domain name (FQDN), has a maximum length of
+	/// 255 bytes [`rfc1035`]
+	///
+	/// [`rfc1035`]: https://tools.ietf.org/html/rfc1035
+	fn gethostbyaddr(&self, addr: IpAddr) -> Result<String<consts::U256>, Self::Error>;
 }

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -1,4 +1,4 @@
-use heapless::{consts, String};
+use heapless::String;
 
 use crate::addr::HostAddr;
 use no_std_net::IpAddr;
@@ -8,8 +8,8 @@ use core::fmt::Debug;
 /// DNS errors
 #[derive(Debug)]
 pub enum DnsError {
-    UnsupportedAddressType,
-    NoSuchHost,
+	UnsupportedAddressType,
+	NoSuchHost,
 }
 
 /// This is the host address type to be returned by `gethostbyname`.
@@ -18,12 +18,12 @@ pub enum DnsError {
 /// will look for `AAAA` records
 #[derive(Clone, Debug, PartialEq)]
 pub enum AddrType {
-    /// Result is `A` record
-    IPv4,
-    /// Result is `AAAA` record
-    IPv6,
-    /// Result is either a `A` record, or a `AAAA` record
-    Either,
+	/// Result is `A` record
+	IPv4,
+	/// Result is `AAAA` record
+	IPv6,
+	/// Result is either a `A` record, or a `AAAA` record
+	Either,
 }
 
 /// This trait is an extension trait for [`TcpStack`] and [`UdpStack`] for dns
@@ -37,18 +37,18 @@ pub enum AddrType {
 /// [`ToSocketAddrs`]:
 /// https://doc.rust-lang.org/std/net/trait.ToSocketAddrs.html
 pub trait Dns {
-    /// The type returned when we have an error
-    type Error: Into<DnsError> + Debug;
+	/// The type returned when we have an error
+	type Error: Into<DnsError> + Debug;
 
-    /// Resolve the first ip address of a host, given its hostname and a desired
-    /// address record type to look for
-    fn gethostbyname(&self, hostname: &str, addr_type: AddrType) -> Result<HostAddr, Self::Error>;
+	/// Resolve the first ip address of a host, given its hostname and a desired
+	/// address record type to look for
+	fn gethostbyname(&self, hostname: &str, addr_type: AddrType) -> Result<HostAddr, Self::Error>;
 
-    /// Resolve the hostname of a host, given its ip address
-    ///
-    /// **Note**: A fully qualified domain name (FQDN), has a maximum length of
-    /// 255 bytes [`rfc1035`]
-    ///
-    /// [`rfc1035`]: https://tools.ietf.org/html/rfc1035
-    fn gethostbyaddr(&self, addr: IpAddr) -> Result<String<consts::U256>, Self::Error>;
+	/// Resolve the hostname of a host, given its ip address
+	///
+	/// **Note**: A fully qualified domain name (FQDN), has a maximum length of
+	/// 255 bytes [`rfc1035`]
+	///
+	/// [`rfc1035`]: https://tools.ietf.org/html/rfc1035
+	fn gethostbyaddr(&self, addr: IpAddr) -> Result<String<256>, Self::Error>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,31 +1,29 @@
 #![cfg_attr(not(test), no_std)]
-
 //#![deny(missing_docs)]
 #![deny(unsafe_code)]
 
 pub mod tcp;
 //mod udp;
-pub mod dns;
 pub mod addr;
+pub mod dns;
 
 use tcp::TcpStack;
 
-use core::fmt::Debug;
+use crate::dns::{Dns, DnsError};
 use crate::tcp::TcpError;
-use crate::dns::{DnsError, Dns};
+use core::fmt::Debug;
 
 /// Aggregation and homegenation of IP network stacks
 pub trait IpNetworkDriver {
-    type TcpSocket;
-    type TcpError: Into<TcpError> + Debug;
+	type TcpSocket;
+	type TcpError: Into<TcpError> + Debug;
 
-    type DnsError: Into<DnsError> + Debug;
+	type DnsError: Into<DnsError> + Debug;
 
-    //type UdpSocket;
-    //type UdpError: Into<UdpError> + Debug;
+	//type UdpSocket;
+	//type UdpError: Into<UdpError> + Debug;
 
-    fn tcp(&self) -> &dyn TcpStack<TcpSocket=Self::TcpSocket, Error=Self::TcpError>;
-    //fn udp() -> &dyn UdpStack<Error = NetworkError>;
-    fn dns(&self) -> &dyn Dns<Error=Self::DnsError>;
+	fn tcp(&self) -> &dyn TcpStack<TcpSocket = Self::TcpSocket, Error = Self::TcpError>;
+	//fn udp() -> &dyn UdpStack<Error = NetworkError>;
+	fn dns(&self) -> &dyn Dns<Error = Self::DnsError>;
 }
-

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -1,38 +1,37 @@
-
 use crate::addr::HostSocketAddr;
 
 use core::fmt::Debug;
 
 /// Whether a socket should block when a read/write can't be performed, or return early.
 pub enum Mode {
-    /// The function call will wait as long as necessary to complete the operation
-    Blocking,
-    /// The function call will not wait at all to complete the operation, and only do what it can.
-    NonBlocking,
-    /// The function call will wait only up the given number of milliseconds to complete the operation.
-    Timeout(u16),
+	/// The function call will wait as long as necessary to complete the operation
+	Blocking,
+	/// The function call will not wait at all to complete the operation, and only do what it can.
+	NonBlocking,
+	/// The function call will wait only up the given number of milliseconds to complete the operation.
+	Timeout(u16),
 }
 
 /// Network errors
 #[non_exhaustive]
 #[derive(Debug)]
 pub enum TcpError {
-    NoAvailableSockets,
-    ConnectionRefused,
-    SocketNotOpen,
-    WriteError,
-    ReadError,
-    Timeout,
-    Busy,
-    Impl(TcpImplError),
+	NoAvailableSockets,
+	ConnectionRefused,
+	SocketNotOpen,
+	WriteError,
+	ReadError,
+	Timeout,
+	Busy,
+	Impl(TcpImplError),
 }
 
 #[non_exhaustive]
 #[derive(Debug)]
 pub enum TcpImplError {
-    InitializationError,
-    ErrorCode(u32),
-    Unknown,
+	InitializationError,
+	ErrorCode(u32),
+	Unknown,
 }
 
 /// This trait is implemented by TCP/IP stacks. You could, for example, have an implementation
@@ -40,38 +39,37 @@ pub enum TcpImplError {
 /// which knows how to driver the Rust Standard Library's `std::net` module. Given this trait, you can how
 /// write a portable HTTP client which can work with either implementation.
 pub trait TcpStack {
-    /// The type returned when we create a new TCP socket
-    type TcpSocket;
-    /// The type returned when we have an error
-    type Error: Into<TcpError> + Debug;
+	/// The type returned when we create a new TCP socket
+	type TcpSocket;
+	/// The type returned when we have an error
+	type Error: Into<TcpError> + Debug;
 
-    /// Open a new TCP socket. The socket starts in the unconnected state.
-    fn open(&self, mode: Mode) -> Result<Self::TcpSocket, Self::Error>;
+	/// Open a new TCP socket. The socket starts in the unconnected state.
+	fn open(&self, mode: Mode) -> Result<Self::TcpSocket, Self::Error>;
 
-    /// Connect to the given remote host and port.
-    fn connect(
-        &self,
-        socket: Self::TcpSocket,
-        remote: HostSocketAddr,
-    ) -> Result<Self::TcpSocket, Self::Error>;
+	/// Connect to the given remote host and port.
+	fn connect(
+		&self,
+		socket: Self::TcpSocket,
+		remote: HostSocketAddr,
+	) -> Result<Self::TcpSocket, Self::Error>;
 
-    /// Check if this socket is connected
-    fn is_connected(&self, socket: &Self::TcpSocket) -> Result<bool, Self::Error>;
+	/// Check if this socket is connected
+	fn is_connected(&self, socket: &Self::TcpSocket) -> Result<bool, Self::Error>;
 
-    /// Write to the stream. Returns the number of bytes written is returned
-    /// (which may be less than `buffer.len()`), or an error.
-    fn write(&self, socket: &mut Self::TcpSocket, buffer: &[u8]) -> nb::Result<usize, Self::Error>;
+	/// Write to the stream. Returns the number of bytes written is returned
+	/// (which may be less than `buffer.len()`), or an error.
+	fn write(&self, socket: &mut Self::TcpSocket, buffer: &[u8]) -> nb::Result<usize, Self::Error>;
 
-    /// Read from the stream. Returns `Ok(n)`, which means `n` bytes of
-    /// data have been received and they have been placed in
-    /// `&buffer[0..n]`, or an error.
-    fn read(
-        &self,
-        socket: &mut Self::TcpSocket,
-        buffer: &mut [u8],
-    ) -> nb::Result<usize, Self::Error>;
+	/// Read from the stream. Returns `Ok(n)`, which means `n` bytes of
+	/// data have been received and they have been placed in
+	/// `&buffer[0..n]`, or an error.
+	fn read(
+		&self,
+		socket: &mut Self::TcpSocket,
+		buffer: &mut [u8],
+	) -> nb::Result<usize, Self::Error>;
 
-    /// Close an existing TCP socket.
-    fn close(&self, socket: Self::TcpSocket) -> Result<(), Self::Error>;
+	/// Close an existing TCP socket.
+	fn close(&self, socket: Self::TcpSocket) -> Result<(), Self::Error>;
 }
-


### PR DESCRIPTION
- update to use current heapless (const generics)
- run `cargo fmt` on entire repo

commits are not cleanly separated, because git's UI is still horrific; the actual non-fmt changes can be seen in `8ffbbab`.